### PR TITLE
fix: add explicit variable declarations

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -39,7 +39,7 @@ module.exports = (function() {
         peg$c4 = function(first, rest) {
         		var result = []
         		result.push(first)
-        		for (i = 0; i< rest.length; i++){
+        		for (var i = 0; i< rest.length; i++){
         			result.push(rest[i])
         		}
         		return result;
@@ -201,7 +201,7 @@ module.exports = (function() {
         var expectedDescs = new Array(expected.length),
             expectedDesc, foundDesc, i;
 
-        for (i = 0; i < expected.length; i++) {
+        for (var i = 0; i < expected.length; i++) {
           expectedDescs[i] = expected[i].description;
         }
 


### PR DESCRIPTION
Needed for it to work in strict mode. without it `ReferenceError: i is not defined` is thrown